### PR TITLE
Quote bind DN

### DIFF
--- a/proxy_ldap.conf.template
+++ b/proxy_ldap.conf.template
@@ -71,7 +71,7 @@ LogLevel ${LOGLEVEL}
       fi;)
 
       $([[ -v LDAP_BIND_DN ]] && { echo "
-          AuthLDAPBindDN ${LDAP_BIND_DN}
+          AuthLDAPBindDN \\"${LDAP_BIND_DN}\\"
       ";} )
 
       $([[ -v LDAP_BIND_PASSWORD ]] && { echo "


### PR DESCRIPTION
Without the quotes, apache will error out if there are spaces in the DN.
Thanks!
