### PR TITLE
Fix over-escaping

### DIFF
--- a/proxy_ldap.conf.template
+++ b/proxy_ldap.conf.template
@@ -71,7 +71,7 @@ LogLevel ${LOGLEVEL}
       fi;)
 
       $([[ -v LDAP_BIND_DN ]] && { echo "
-          AuthLDAPBindDN \\"${LDAP_BIND_DN}\\"
+          AuthLDAPBindDN \"${LDAP_BIND_DN}\"
       ";} )
 
       $([[ -v LDAP_BIND_PASSWORD ]] && { echo "


### PR DESCRIPTION
Sorry, PR #5 had an extra escape character which worked in sed but not directly in run.sh.